### PR TITLE
change deprecated decorator

### DIFF
--- a/loader/base_loader.py
+++ b/loader/base_loader.py
@@ -54,12 +54,10 @@ class BaseLoader(ABC):
         tc_offset = datetime.now(pytz.timezone(self.time_zone)).utcoffset()
         return time + tc_offset
 
-    @classmethod
     @abstractmethod
     def make_track_dict(self):
         pass
 
-    @classmethod
     @abstractmethod
     def get_all_track_data(self):
         pass

--- a/loader/base_loader.py
+++ b/loader/base_loader.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractclassmethod
+from abc import ABC, abstractmethod
 from collections import defaultdict
 from datetime import datetime
 
@@ -54,10 +54,12 @@ class BaseLoader(ABC):
         tc_offset = datetime.now(pytz.timezone(self.time_zone)).utcoffset()
         return time + tc_offset
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def make_track_dict(self):
         pass
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def get_all_track_data(self):
         pass


### PR DESCRIPTION
@abstractclassmethod is deprecated since python3.3.
https://docs.python.org/3.8/library/abc.html#abc.abstractclassmethod