### PR TITLE
Add feature: WakaTime

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -6,7 +6,7 @@ Make everything a GitHub svg poster and [skyline](https://skyline.github.com/)!
 ![](https://github.com/yihong0618/GitHubPoster/blob/main/examples/twitter.svg)
 ![](https://github.com/yihong0618/GitHubPoster/blob/main/examples/shanbay.svg)
 
-## 支持
+## Support
 - **[Strava](#strava)**
 - **[Nintendo Switch](#ns)**
 - **[GPX](#GPX)**
@@ -18,6 +18,7 @@ Make everything a GitHub svg poster and [skyline](https://skyline.github.com/)!
 - **[GitHub](#GitHub)**
 - **[GitLab](#GitLab)**
 - **[Kindle](#Kindle)**
+- **[WakaTime](#WakaTime)**
 
 ## Download
 ```
@@ -252,6 +253,20 @@ Find your [Amazon](https://www.amazon.com/) Cookie
 
 ```python
 python3 cli.py --type kindle --kindle_cookie ${kindle_cookie} --year 2018-2021
+```
+
+</details>
+
+### WakaTime
+
+<details>
+<summary>Make your <code>WakaTime </code> poster</summary>
+<br>
+
+Find your own WakaTime API Key at: [WakaTime API Key](https://wakatime.com/settings/api-key)
+
+```python
+python cli.py --type wakatime --wakatime_key="your_wakatime_api_key" --year 2019-2021
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -287,6 +287,20 @@ python3 cli.py --type kindle --kindle_cookie ${kindle_cookie} --is-cn --year 201
 
 </details>
 
+### WakaTime
+
+<details>
+<summary>Make your <code>WakaTime </code> poster</summary>
+<br>
+
+在WakaTime官网获取你的 WakaTime API Key：[WakaTime API Key](https://wakatime.com/settings/api-key)
+
+```python
+python cli.py --type wakatime --wakatime_key="your_wakatime_api_key" --year 2019-2021
+```
+
+</details>
+
 
 # 参与项目
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Make everything a GitHub svg poster and [skyline](https://skyline.github.com/)!
 - **[GitHub](#GitHub)**
 - **[GitLab](#GitLab)**
 - **[Kindle](#Kindle)**
+- **[WakaTime](#WakaTime)**
 
 
 ## 下载

--- a/cli.py
+++ b/cli.py
@@ -61,7 +61,7 @@ UNIT_DICT = {
     "github": "cons",
     "gitlab": "cons",
     "kindle": "days",
-    "wakatime": "cons",
+    "wakatime": "mins",
 }
 
 ## default color for different type
@@ -390,7 +390,7 @@ def main():
         dest="wakatime_key",
         type=str,
         default="",
-        help="",
+        help="your wakatime api key here, more info: https://wakatime.com/settings/api-key",
     )
 
     args = args_parser.parse_args()

--- a/cli.py
+++ b/cli.py
@@ -23,6 +23,7 @@ from loader import (
     TwitterLoader,
     YouTubeLoader,
     KindleLoader,
+    WakaTimeLoader,
 )
 from skyline import Skyline
 
@@ -41,6 +42,7 @@ LOADER_DICT = {
     "github": GitHubLoader,
     "gitlab": GitLabLoader,
     "kindle": KindleLoader,
+    "wakatime": WakaTimeLoader,
 }
 
 # TODO refactor
@@ -59,6 +61,7 @@ UNIT_DICT = {
     "github": "cons",
     "gitlab": "cons",
     "kindle": "days",
+    "wakatime": "cons",
 }
 
 ## default color for different type
@@ -71,6 +74,7 @@ TRACK_COLOR_DICT = {
     "github": "#9BE9A8",
     "gitlab": "#ACD5F2",
     "kindle": "#2A4A7B",
+    "wakatime": "#9BE9A8",
 }
 
 TYPES = '", "'.join(LOADER_DICT.keys())
@@ -378,6 +382,15 @@ def main():
         dest="is_cn",
         action="store_true",
         help="if accout is CN",
+    )
+
+    # WakaTime
+    args_parser.add_argument(
+        "--wakatime_key",
+        dest="wakatime_key",
+        type=str,
+        default="",
+        help="",
     )
 
     args = args_parser.parse_args()

--- a/cli.py
+++ b/cli.py
@@ -16,14 +16,14 @@ from loader import (
     GitHubLoader,
     GitLabLoader,
     GPXLoader,
+    KindleLoader,
     LeetcodeLoader,
     NSLoader,
     ShanBayLoader,
     StravaLoader,
     TwitterLoader,
-    YouTubeLoader,
-    KindleLoader,
     WakaTimeLoader,
+    YouTubeLoader,
 )
 from skyline import Skyline
 

--- a/loader/__init__.py
+++ b/loader/__init__.py
@@ -11,5 +11,5 @@ from .ns_loader import NSLoader
 from .shanbay_loader import ShanBayLoader
 from .strava_loader import StravaLoader
 from .twitter_loader import TwitterLoader
-from .youtube_loader import YouTubeLoader
 from .wakatime_loader import WakaTimeLoader
+from .youtube_loader import YouTubeLoader

--- a/loader/__init__.py
+++ b/loader/__init__.py
@@ -12,3 +12,4 @@ from .shanbay_loader import ShanBayLoader
 from .strava_loader import StravaLoader
 from .twitter_loader import TwitterLoader
 from .youtube_loader import YouTubeLoader
+from .wakatime_loader import WakaTimeLoader

--- a/loader/config.py
+++ b/loader/config.py
@@ -54,3 +54,6 @@ KINDLE_CN_HISTORY_URL = "https://www.amazon.cn/kindle/reading/insights"
 KINDLE_HEADER = {
     "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/1AE148",
 }
+
+# WakaTime
+WAKATIME_SUMMARY_URL = "https://wakatime.com/api/v1/users/current/summaries?api_key={wakatime_key}&start={from_year}&end={to_year}"

--- a/loader/gitlab_loader.py
+++ b/loader/gitlab_loader.py
@@ -17,7 +17,7 @@ class GitLabLoader(BaseLoader):
         self.to_year = to_year
         self.user_name = kwargs.get("gitlab_user_name", "")
         self.gitlab_base_url = kwargs.get("gitlab_base_url") or "https://gitlab.com"
-        self.gitlab_session = kwargs.get('gitlab_session')
+        self.gitlab_session = kwargs.get("gitlab_session")
         self._make_years_list()
         self.left_dates = []
 
@@ -27,14 +27,18 @@ class GitLabLoader(BaseLoader):
 
     def _set_cookies(self):
         if self.gitlab_session:
-            return {'_gitlab_session': self.gitlab_session}
+            return {"_gitlab_session": self.gitlab_session}
 
         return {}
 
     def make_latest_date_dict(self):
         try:
-            r = requests.get(GITLAB_LATEST_URL.format(gitlab_base_url=self.gitlab_base_url, user_name=self.user_name),
-                             cookies=self._set_cookies())
+            r = requests.get(
+                GITLAB_LATEST_URL.format(
+                    gitlab_base_url=self.gitlab_base_url, user_name=self.user_name
+                ),
+                cookies=self._set_cookies(),
+            )
             date_dict = r.json()
             min_date = min(date_dict.keys())
             self.number_by_date_dict = date_dict
@@ -49,8 +53,12 @@ class GitLabLoader(BaseLoader):
         for d in self.left_dates:
             try:
                 r = requests.get(
-                    GITLAB_ONE_DAY_URL.format(gitlab_base_url=self.gitlab_base_url,
-                                              user_name=self.user_name, date_str=d), cookies=self._set_cookies()
+                    GITLAB_ONE_DAY_URL.format(
+                        gitlab_base_url=self.gitlab_base_url,
+                        user_name=self.user_name,
+                        date_str=d,
+                    ),
+                    cookies=self._set_cookies(),
                 )
                 # spider rule
                 time.sleep(0.1)

--- a/loader/wakatime_loader.py
+++ b/loader/wakatime_loader.py
@@ -1,0 +1,49 @@
+import time
+
+import pendulum
+import requests
+
+from .base_loader import BaseLoader
+from .config import WAKATIME_SUMMARY_URL
+
+
+class WakaTimeLoader(BaseLoader):
+    def __init__(self, from_year, to_year, **kwargs) -> None:
+        super().__init__()
+        assert to_year >= from_year
+        self.from_year = from_year
+        self.to_year = to_year
+        self.wakatime_key = kwargs.get("wakatime_key", "")
+        self._make_years_list()
+
+    def get_api_data(self):
+        data_list = []
+        for year in range(self.from_year, self.to_year + 1):
+            r = requests.get(
+                WAKATIME_SUMMARY_URL.format(
+                    wakatime_key=self.wakatime_key,
+                    from_year="{}-01-01".format(year),
+                    to_year="{}-12-31".format(year))
+            )
+            if not r.ok:
+                print(r.text)
+                return data_list
+            data = r.json()
+            data_list.extend(data["data"])
+            time.sleep(1)
+        return data_list
+
+    def make_track_dict(self):
+        data_list = self.get_api_data()
+        for d in data_list:
+            if d:
+                date = d["range"]["date"]
+                self.number_by_date_dict[date] += d["grand_total"]["total_seconds"]
+                # self.number_by_date_dict[date] += 1
+        for _, v in self.number_by_date_dict.items():
+            self.number_list.append(v)
+
+    def get_all_track_data(self):
+        self.make_track_dict()
+        self.make_special_number()
+        return self.number_by_date_dict, self.year_list

--- a/loader/wakatime_loader.py
+++ b/loader/wakatime_loader.py
@@ -23,7 +23,8 @@ class WakaTimeLoader(BaseLoader):
                 WAKATIME_SUMMARY_URL.format(
                     wakatime_key=self.wakatime_key,
                     from_year="{}-01-01".format(year),
-                    to_year="{}-12-31".format(year))
+                    to_year="{}-12-31".format(year),
+                )
             )
             if not r.ok:
                 print(r.text)
@@ -38,8 +39,9 @@ class WakaTimeLoader(BaseLoader):
         for d in data_list:
             if d:
                 date = d["range"]["date"]
-                self.number_by_date_dict[date] += d["grand_total"]["total_seconds"]
-                # self.number_by_date_dict[date] += 1
+                self.number_by_date_dict[date] += (
+                    d["grand_total"]["total_seconds"] / 60.0
+                )
         for _, v in self.number_by_date_dict.items():
             self.number_list.append(v)
 


### PR DESCRIPTION
Hi, there.

I just add the `WakaTime` feature for this repo.

Here is a example:

![wakatime](https://user-images.githubusercontent.com/40811521/122011018-434d9300-cdee-11eb-8a9e-a8c5b9618c00.png)

I'm not so familiar with this project honestly speaking.

So i just use the second to calculate the counts, maybe your can change it later.

Here a typical json item is json result:

```json
{
      "categories": [],
      "dependencies": [],
      "editors": [],
      "grand_total": {
        "digital": "0:00",
        "hours": 0,
        "minutes": 0,
        "text": "0 secs",
        "total_seconds": 0
      },
      "languages": [],
      "machines": [],
      "operating_systems": [],
      "projects": [],
      "range": {
        "date": "2020-01-01",
        "end": "2020-01-01T15:59:59Z",
        "start": "2019-12-31T16:00:00Z",
        "text": "Wed Jan 1st 2020",
        "timezone": "Asia/Shanghai"
      }
}
```

I use `item["range"]["date"]` for date, and `item["grand_total"]["total_seconds"]` for value. 
