### PR TITLE
feat: add notion loader

### DIFF
--- a/.github/workflows/run_poster_generate.yml
+++ b/.github/workflows/run_poster_generate.yml
@@ -118,6 +118,11 @@ jobs:
         run: |
           python3 -m github_poster dota2 --dota2_id "${{ secrets.DOTA2_ID }}" --me ${{ env.ME }}
 
+      - name: Run sync notion script
+        if: contains(env.TYPE, 'notion')
+        run: |
+          python3 -m github_poster notion --notion_token "${{ secrets.NOTION_TOKEN }}" --database_id "${{ secrets.NOTION_DATABASE_ID }}" --prop_name "${{ secrets.NOTION_PROP_NAME }}" --me ${{ env.ME }}
+
       # change the types to yours
       - name: Run sync multiple script
         if: contains(env.TYPE, 'multiple')

--- a/README-EN.md
+++ b/README-EN.md
@@ -26,6 +26,7 @@ Make everything a GitHub svg poster and [skyline](https://skyline.github.com/)!
 - **[WakaTime](#WakaTime)**
 - **[Dota2](#Dota2)**
 - **[Nike](#Nike)**
+- **[Notion](#Notion)**
 - **[Garmin](#Garmin)**
 - **[Forest](#Forest)**
 - **[Json](#Json)**
@@ -356,6 +357,34 @@ github_poster dota2 --dota2_id="your dota2 id" --year 2017-2018
 python3 -m github_poster nike --nike_refresh_token="your nike_refresh_token" --year 2012-2021
 or
 github_poster nike --nike_refresh_token="your nike_refresh_token" --year 2012-2021
+```
+
+</details>
+
+### Notion
+
+<details>
+<summary>Make your <code> Notion </code> poster</summary>
+
+Get Notion `Internal Integration Token`(notion_token), see [here](https://developers.notion.com/docs/authorization#authorizing-internal-integrations) for more details.
+
+1. Sign in [Notion](https://www.notion.so/my-integrations) developers site
+2. Click 'New integration' to create a new token
+3. You can see `Internal Integration Token` below `Secrets` after submit
+
+Get Notion Database ID(database_id), see [here](https://developers.notion.com/docs/working-with-databases#adding-pages-to-a-database) for more details.
+
+1. Open the database as a full page in Notion
+2. Use the `Share` menu to `Copy link`, and you'll get a URL looks like `https://www.notion.so/{workspace_name}/{database_id}?v={view_id}`
+3. The part that corresponds to `{database_id}` is the ID of your Notion Database
+
+Note：The database need a property which type is `Date`, the value of it will be used to generate the poster. 
+The name of the date property shoould be set as option `prop_name`'s value，default value is `Datetime`
+
+```
+python3 -m github_poster notion --notion_token="your notion_token" --database_id="your database_id" --prop_name="your prop_name"
+or
+github_poster notion --notion_token="your notion_token" --database_id="your database_id" --prop_name="your prop_name"
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Make everything a GitHub svg poster and [skyline](https://skyline.github.com/)!
 - **[WakaTime](#WakaTime)**
 - **[Dota2](#Dota2)**
 - **[Nike](#Nike)**
+- **[Notion](#Notion)**
 - **[Garmin](#Garmin)**
 - **[Forest](#Forest)**
 - **[Json](#json)**
@@ -409,6 +410,33 @@ github_poster dota2 --dota2_id="your dota2 id" --year 2017-2018
 python3 -m github_poster nike --nike_refresh_token="your nike_refresh_token" --year 2012-2021
 or
 github_poster nike --nike_refresh_token="your nike_refresh_token" --year 2012-2021
+```
+
+</details>
+
+### Notion
+
+<details>
+<summary>Make your <code> Notion </code> poster</summary>
+
+获取 Notion 的 `Internal Integration Token`(notion_token)，查看[官方文档](https://developers.notion.com/docs/authorization#authorizing-internal-integrations)获取更多信息。
+
+1. 登录 [Notion](https://www.notion.so/my-integrations) 开发者网站
+2. 点击「New integration」添加基础信息后，创建新的 Token
+3. 提交后可以看到 `Secrets` 下的 `Internal Integration Token`
+
+获取用于生成 Poster 的 Notion 数据库 ID(database_id)，查看[官方文档](https://developers.notion.com/docs/working-with-databases#adding-pages-to-a-database)获取更多信息。
+
+1. 以全屏页面打开数据库
+2. 复制页面链接，链接组成应该是 `https://www.notion.so/{workspace_name}/{database_id}?v={view_id}` 这样的
+3. 其中 `{database_id}` 部分即为数据库 ID
+
+注：数据库需要添加一个属性类型为 `Date` 的日期属性，该属性的值将作为生成 Poster 的日期数据使用。在生成时需将该日期属性的名称作为选项 `prop_name` 的值，默认值为 `Datetime`
+
+```
+python3 -m github_poster notion --notion_token="your notion_token" --database_id="your database_id" --prop_name="your prop_name"
+or
+github_poster notion --notion_token="your notion_token" --database_id="your database_id" --prop_name="your prop_name"
 ```
 
 </details>

--- a/github_poster/loader/__init__.py
+++ b/github_poster/loader/__init__.py
@@ -14,6 +14,7 @@ from github_poster.loader.json_loader import JsonLoader
 from github_poster.loader.kindle_loader import KindleLoader
 from github_poster.loader.leetcode_loader import LeetcodeLoader
 from github_poster.loader.multiple_loader import MutipleLoader
+from github_poster.loader.notion_loader import NotionLoader
 from github_poster.loader.nrc_loader import NRCLoader
 from github_poster.loader.ns_loader import NSLoader
 from github_poster.loader.shanbay_loader import ShanBayLoader
@@ -43,6 +44,7 @@ LOADER_DICT = {
     "dota2": Dota2Loader,
     "multiple": MutipleLoader,
     "nike": NRCLoader,
+    "notion": NotionLoader,
     "garmin": GarminLoader,
     "forest": ForestLoader,
     "json": JsonLoader,
@@ -68,6 +70,7 @@ __all__ = (
     "WakaTimeLoader",
     "YouTubeLoader",
     "MutipleLoader",
+    "NotionLoader",
     "NRCLoader",
     "LOADER_DICT",
     "ForestLoader",

--- a/github_poster/loader/config.py
+++ b/github_poster/loader/config.py
@@ -106,3 +106,7 @@ JIKE_PERSON_URL = "https://web.okjike.com/u/{user_id}"
 
 # bbdc
 BBDC_API_URL = "https://learnywhere.cn/bb/dashboard/profile/search?userId={user_id}"
+
+# Notion
+NOTION_API_URL = "https://api.notion.com/v1/databases/{database_id}/query"
+NOTION_API_VERSION = "2021-08-16"

--- a/github_poster/loader/notion_loader.py
+++ b/github_poster/loader/notion_loader.py
@@ -90,5 +90,4 @@ class NotionLoader(BaseLoader):
     def get_all_track_data(self):
         self.make_track_dict()
         self.make_special_number()
-        print(self.number_by_date_dict, self.number_list)
         return self.number_by_date_dict, self.year_list

--- a/github_poster/loader/notion_loader.py
+++ b/github_poster/loader/notion_loader.py
@@ -1,0 +1,94 @@
+import time
+from collections import defaultdict
+
+import pendulum
+import requests
+
+from github_poster.loader.base_loader import BaseLoader, LoadError
+from github_poster.loader.config import NOTION_API_URL, NOTION_API_VERSION
+
+
+class NotionLoader(BaseLoader):
+    track_color = "#40C463"
+    unit = "times"
+
+    def __init__(self, from_year, to_year, _type, **kwargs):
+        super().__init__(from_year, to_year, _type)
+        self.number_by_date_dict = defaultdict(int)
+        self.notion_token = kwargs.get("notion_token", "")
+        self.database_id = kwargs.get("database_id", "")
+        self.prop_name = kwargs.get("prop_name", "")
+
+    @classmethod
+    def add_loader_arguments(cls, parser, optional):
+        parser.add_argument(
+            "--notion_token",
+            dest="notion_token",
+            type=str,
+            help="The Notion internal integration token.",
+        )
+        parser.add_argument(
+            "--database_id",
+            dest="database_id",
+            type=str,
+            help="The Notion database id.",
+        )
+        parser.add_argument(
+            "--prop_name",
+            dest="prop_name",
+            type=str,
+            default="Datetime",
+            required=optional,
+            help="The database property name which stored the datetime.",
+        )
+
+    def get_api_data(self, start_cursor="", page_size=100, data_list=[]):
+
+        payload = {"page_size": page_size}
+        if start_cursor:
+            payload.update({"start_cursor": start_cursor})
+
+        headers = {
+            "Accept": "application/json",
+            "Notion-Version": NOTION_API_VERSION,
+            "Content-Type": "application/json",
+            "Authorization": "Bearer " + self.notion_token,
+        }
+
+        resp = requests.post(
+            NOTION_API_URL.format(database_id=self.database_id),
+            json=payload,
+            headers=headers,
+        )
+
+        if not resp.ok:
+            raise LoadError("Can not get Notion data, please check your config")
+        data = resp.json()
+        results = data["results"]
+        next_cursor = data["next_cursor"]
+        data_list.extend(results)
+        if not data["has_more"]:
+            return data_list
+        # Avoid request limits
+        # The rate limit for incoming requests is an average
+        # of 3 requests per second.
+        # See https://developers.notion.com/reference/request-limits
+        time.sleep(0.3)
+        return self.get_api_data(
+            start_cursor=next_cursor, page_size=page_size, data_list=data_list
+        )
+
+    def make_track_dict(self):
+        data_list = self.get_api_data()
+        for result in data_list:
+            dt = result["properties"][self.prop_name]["date"]["start"]
+            date_str = pendulum.parse(dt).to_date_string()
+            self.number_by_date_dict[date_str] += 1
+        for _, v in self.number_by_date_dict.items():
+            self.number_list.append(v)
+
+    def get_all_track_data(self):
+        self.make_track_dict()
+        self.make_special_number()
+        print(self.number_by_date_dict, self.number_list)
+        return self.number_by_date_dict, self.year_list


### PR DESCRIPTION
Add Notion Loader.

Use your Notion as a CMS, get data from Notion database to generate poster.

- notion_token: The Notion internal integration token, see [here](https://developers.notion.com/docs/authorization#authorizing-internal-integrations) for more detail.
- database_id: The Notion database id, you can learn from [Where can I find my database's ID?](https://developers.notion.com/docs/working-with-databases#adding-pages-to-a-database)
- prop_name: The Notion database property name which stored the date and time, an ISO 8601 format date, with optional time.

**NOTE**

The `prop_name` property should be set as `Date` property type, or the loader won't work properly.

![Property Type Date](https://user-images.githubusercontent.com/8568876/150629419-bf1c8c0f-730f-4291-bf22-85ee6e3345e2.png)

---

[A Notion template](https://ruter.notion.site/581b6eb0eb714511b93832a8dd144a36) as example:

![Example](https://user-images.githubusercontent.com/8568876/150628567-4ee841f8-144a-431f-8eda-11ea60093c3d.svg)
