### PR TITLE
Lazy importing each loaders's dependencies

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -42,7 +42,7 @@ git clone https://github.com/yihong0618/GitHubPoster.git
 ## pip install
 
 ```
-pip3 install -U github_poster
+pip3 install -U 'github_poster[all]'
 ```
 
 ## Install(Python3.6+)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ git clone https://github.com/yihong0618/GitHubPoster.git
 ## pip 安装
 
 ```
-pip3 install -U github_poster
+pip3 install -U 'github_poster[all]'
 ```
 
 ## 安装(Python3.6+)

--- a/github_poster/circluar_drawer.py
+++ b/github_poster/circluar_drawer.py
@@ -163,7 +163,6 @@ class CircularDrawer(Drawer):
         key_animate,
     ):
         color = self.make_color(self.poster.length_range_by_date, length)
-        color = self.make_color(self.poster.length_range_by_date, length)
         r1 = rr.lower()
         r2 = (
             rr.lower()

--- a/github_poster/cli.py
+++ b/github_poster/cli.py
@@ -4,19 +4,20 @@
 
 import argparse
 import os
+import sys
 
 from github_poster.circluar_drawer import CircularDrawer
 from github_poster.config import TYPE_INFO_DICT
 from github_poster.drawer import Drawer
+from github_poster.err import DepNotInstalledError
 from github_poster.loader import LOADER_DICT
 from github_poster.poster import Poster
-from github_poster.skyline import Skyline
 from github_poster.utils import parse_years
 
 OUT_FOLDER = os.path.join(os.getcwd(), "OUT_FOLDER")
 
 
-def main():
+def run():
     """Handle command line arguments and call other modules as needed."""
     p = Poster()
     args_parser = argparse.ArgumentParser()
@@ -133,6 +134,14 @@ def main():
 
     # generate skyline
     if args.with_skyline:
+        try:
+            from github_poster.skyline import Skyline
+        except ImportError:
+            raise Exception(
+                "Skyline dependencies are not installed, "
+                "please use 'pip3 install -U github_poster[skyline]' to install."
+            )
+
         if args.skyline_year:
             year = args.skyline_year
         else:
@@ -151,6 +160,13 @@ def main():
         )
         s.type_info_dict = TYPE_INFO_DICT
         s.make_skyline()
+
+
+def main():
+    try:
+        run()
+    except DepNotInstalledError as e:
+        print(e, file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/github_poster/cli.py
+++ b/github_poster/cli.py
@@ -137,7 +137,7 @@ def run():
         try:
             from github_poster.skyline import Skyline
         except ImportError:
-            raise Exception(
+            raise DepNotInstalledError(
                 "Skyline dependencies are not installed, "
                 "please use 'pip3 install -U github_poster[skyline]' to install."
             )

--- a/github_poster/err.py
+++ b/github_poster/err.py
@@ -12,3 +12,8 @@ class CircularDrawError(BaseDrawError):
     """
 
     pass
+
+
+class DepNotInstalledError(Exception):
+    def __str__(self):
+        return self.args[0]

--- a/github_poster/err.py
+++ b/github_poster/err.py
@@ -3,17 +3,14 @@ class BaseDrawError(Exception):
     draw github poster wrong
     """
 
-    pass
-
 
 class CircularDrawError(BaseDrawError):
     """
     draw circular poster wrong
     """
 
-    pass
-
 
 class DepNotInstalledError(Exception):
-    def __str__(self):
-        return self.args[0]
+    """
+    optional dependency not installed
+    """

--- a/github_poster/loader/__init__.py
+++ b/github_poster/loader/__init__.py
@@ -13,7 +13,7 @@ from github_poster.loader.jike_loader import JikeLoader
 from github_poster.loader.json_loader import JsonLoader
 from github_poster.loader.kindle_loader import KindleLoader
 from github_poster.loader.leetcode_loader import LeetcodeLoader
-from github_poster.loader.multiple_loader import MutipleLoader
+from github_poster.loader.multiple_loader import MultipleLoader
 from github_poster.loader.notion_loader import NotionLoader
 from github_poster.loader.nrc_loader import NRCLoader
 from github_poster.loader.ns_loader import NSLoader
@@ -43,7 +43,7 @@ LOADER_DICT = {
     "kindle": KindleLoader,
     "wakatime": WakaTimeLoader,
     "dota2": Dota2Loader,
-    "multiple": MutipleLoader,
+    "multiple": MultipleLoader,
     "nike": NRCLoader,
     "notion": NotionLoader,
     "garmin": GarminLoader,
@@ -71,7 +71,7 @@ __all__ = (
     "TwitterLoader",
     "WakaTimeLoader",
     "YouTubeLoader",
-    "MutipleLoader",
+    "MultipleLoader",
     "NotionLoader",
     "NRCLoader",
     "LOADER_DICT",

--- a/github_poster/loader/base_loader.py
+++ b/github_poster/loader/base_loader.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from http.cookies import SimpleCookie
 
 import pendulum
-import pytz
 from requests.utils import cookiejar_from_dict
 
 from github_poster.loader.config import TIME_ZONE
@@ -33,6 +32,11 @@ class BaseLoader(ABC):
         self.special_number2 = None
         self.number_list = []
         self.year_list = self._make_years_list()
+        self.try_import_deps()
+
+    @classmethod
+    def try_import_deps(cls):
+        pass
 
     def _make_years_list(self):
         return list(range(int(self.from_year), int(self.to_year) + 1))
@@ -66,7 +70,7 @@ class BaseLoader(ABC):
             self.special_number2 = number_list_set[-1 * int(number_list_set_len * 0.50)]
 
     def adjust_time(self, time):
-        tc_offset = datetime.now(pytz.timezone(self.time_zone)).utcoffset()
+        tc_offset = datetime.now(pendulum.timezone(self.time_zone)).utcoffset()
         return time + tc_offset
 
     @staticmethod

--- a/github_poster/loader/bilibili_loader.py
+++ b/github_poster/loader/bilibili_loader.py
@@ -1,6 +1,5 @@
 import time
 from collections import defaultdict
-from http.cookies import SimpleCookie
 
 import pendulum
 import requests

--- a/github_poster/loader/from_github_issue_loader.py
+++ b/github_poster/loader/from_github_issue_loader.py
@@ -15,7 +15,7 @@ class GitHubIssuesLoader(BaseLoader):
     @classmethod
     def try_import_deps(cls):
         try:
-            import github
+            import github  # noqa: F401
         except ImportError:
             raise DepNotInstalledError(
                 "GitHub dependencies are not installed, "

--- a/github_poster/loader/from_github_issue_loader.py
+++ b/github_poster/loader/from_github_issue_loader.py
@@ -1,6 +1,6 @@
 import pendulum
-from github import Github
 
+from github_poster.err import DepNotInstalledError
 from github_poster.loader.base_loader import BaseLoader
 
 
@@ -11,6 +11,16 @@ class GitHubIssuesLoader(BaseLoader):
         self.repo_name = kwargs.get("repo_name", "")
         # for private repo
         self.token = kwargs.get("github_token", "")
+
+    @classmethod
+    def try_import_deps(cls):
+        try:
+            import github
+        except ImportError:
+            raise DepNotInstalledError(
+                "GitHub dependencies are not installed, "
+                "please use 'pip3 install -U github_poster[github]' to install."
+            ) from None
 
     @classmethod
     def add_loader_arguments(cls, parser, optional):
@@ -45,6 +55,8 @@ class GitHubIssuesLoader(BaseLoader):
             return 0
 
     def get_api_data(self):
+        from github import Github
+
         if self.token:
             u = Github(self.token)
             me = u.get_user().login

--- a/github_poster/loader/garmin_loader.py
+++ b/github_poster/loader/garmin_loader.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 
-from garminconnect import Garmin
-
+from github_poster.err import DepNotInstalledError
 from github_poster.loader.base_loader import BaseLoader
 
 
@@ -18,6 +17,16 @@ class GarminLoader(BaseLoader):
         self.garmin_password = kwargs.get("garmin_password", "")
         self.is_cn = kwargs.get("cn", False)
         self.client = None
+
+    @classmethod
+    def try_import_deps(cls):
+        try:
+            import garminconnect
+        except ImportError:
+            raise DepNotInstalledError(
+                "Garmin dependencies are not installed, "
+                "please use 'pip3 install -U github_poster[garmin]' to install."
+            ) from None
 
     @classmethod
     def add_loader_arguments(cls, parser, optional):
@@ -37,6 +46,8 @@ class GarminLoader(BaseLoader):
         )
 
     def _get_access(self):
+        from garminconnect import Garmin
+
         try:
             self.client = Garmin(
                 self.garmin_user_name, self.garmin_password, is_cn=self.is_cn

--- a/github_poster/loader/garmin_loader.py
+++ b/github_poster/loader/garmin_loader.py
@@ -21,7 +21,7 @@ class GarminLoader(BaseLoader):
     @classmethod
     def try_import_deps(cls):
         try:
-            import garminconnect
+            import garminconnect  # noqa: F401
         except ImportError:
             raise DepNotInstalledError(
                 "Garmin dependencies are not installed, "

--- a/github_poster/loader/gpx_loader.py
+++ b/github_poster/loader/gpx_loader.py
@@ -20,7 +20,7 @@ class GPXLoader(BaseLoader):
     @classmethod
     def try_import_deps(cls):
         try:
-            import gpxpy
+            import gpxpy  # noqa: F401
         except ImportError:
             raise DepNotInstalledError(
                 "GPX dependencies are not installed, "

--- a/github_poster/loader/gpx_loader.py
+++ b/github_poster/loader/gpx_loader.py
@@ -2,8 +2,7 @@ import datetime
 import os
 from collections import defaultdict
 
-import gpxpy
-
+from github_poster.err import DepNotInstalledError
 from github_poster.loader.base_loader import BaseLoader, LoadError
 from github_poster.loader.config import GPX_ACTIVITY_NAME_TUPLE
 
@@ -17,6 +16,16 @@ class GPXLoader(BaseLoader):
         self.before = None
         self.after = None
         self.base_dir = kwargs.get("gpx_dir", "")
+
+    @classmethod
+    def try_import_deps(cls):
+        try:
+            import gpxpy
+        except ImportError:
+            raise DepNotInstalledError(
+                "GPX dependencies are not installed, "
+                "please use 'pip3 install -U github_poster[gpx]' to install."
+            ) from None
 
     @classmethod
     def add_loader_arguments(cls, parser, optional):
@@ -45,6 +54,8 @@ class GPXLoader(BaseLoader):
                 yield path_name
 
     def __parse_gpx(self, file_name):
+        import gpxpy
+
         with open(file_name) as f:
             gpx = gpxpy.parse(f)
             try:

--- a/github_poster/loader/jike_loader.py
+++ b/github_poster/loader/jike_loader.py
@@ -1,6 +1,5 @@
 import json
 import time
-from http.cookies import SimpleCookie
 from random import randint
 from re import compile
 

--- a/github_poster/loader/multiple_loader.py
+++ b/github_poster/loader/multiple_loader.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from github_poster.loader.base_loader import BaseLoader
 
 
-class MutipleLoader(BaseLoader):
+class MultipleLoader(BaseLoader):
     def __init__(self, from_year, to_year, _type, **kwargs):
         super().__init__(from_year, to_year, _type)
         self.types = kwargs.get("types", "")

--- a/github_poster/loader/strava_loader.py
+++ b/github_poster/loader/strava_loader.py
@@ -1,8 +1,7 @@
 import datetime
 from collections import defaultdict
 
-import stravalib
-
+from github_poster.err import DepNotInstalledError
 from github_poster.loader.base_loader import BaseLoader, LoadError
 
 
@@ -11,6 +10,8 @@ class StravaLoader(BaseLoader):
 
     def __init__(self, from_year, to_year, _type, **kwargs):
         super().__init__(from_year, to_year, _type)
+        import stravalib
+
         self.before = None
         self.after = None
         self.number_by_date_dict = defaultdict(float)
@@ -19,6 +20,16 @@ class StravaLoader(BaseLoader):
         self.client_secret = kwargs.get("strava_client_secret", "")
         self.refresh_token = kwargs.get("strava_refresh_token", "")
         self.strava_access = False
+
+    @classmethod
+    def try_import_deps(cls):
+        try:
+            import stravalib
+        except ImportError:
+            raise DepNotInstalledError(
+                "Strava dependencies are not installed, "
+                "please use 'pip3 install -U github_poster[strava]' to install."
+            ) from None
 
     @classmethod
     def add_loader_arguments(cls, parser, optional):

--- a/github_poster/loader/strava_loader.py
+++ b/github_poster/loader/strava_loader.py
@@ -24,7 +24,7 @@ class StravaLoader(BaseLoader):
     @classmethod
     def try_import_deps(cls):
         try:
-            import stravalib
+            import stravalib  # noqa: F401
         except ImportError:
             raise DepNotInstalledError(
                 "Strava dependencies are not installed, "

--- a/github_poster/loader/twitter_loader.py
+++ b/github_poster/loader/twitter_loader.py
@@ -1,5 +1,4 @@
-import twint
-
+from github_poster.err import DepNotInstalledError
 from github_poster.loader.base_loader import BaseLoader
 
 
@@ -9,8 +8,20 @@ class TwitterLoader(BaseLoader):
 
     def __init__(self, from_year, to_year, _type, **kwargs):
         super().__init__(from_year, to_year, _type)
+        import twint
+
         self.user_name = kwargs.get("twitter_user_name", "")
         self.c = twint.Config()
+
+    @classmethod
+    def try_import_deps(cls):
+        try:
+            import twint
+        except ImportError:
+            raise DepNotInstalledError(
+                "Twitter dependencies are not installed, "
+                "please use 'pip3 install -U github_poster[twitter]' to install."
+            ) from None
 
     @classmethod
     def add_loader_arguments(cls, parser, optional):
@@ -23,6 +34,8 @@ class TwitterLoader(BaseLoader):
         )
 
     def get_api_data(self):
+        import twint
+
         self.c.Username = self.user_name
         self.c.Custom["tweet"] = ["id"]
         self.c.Custom["user"] = ["bio"]

--- a/github_poster/loader/twitter_loader.py
+++ b/github_poster/loader/twitter_loader.py
@@ -16,7 +16,7 @@ class TwitterLoader(BaseLoader):
     @classmethod
     def try_import_deps(cls):
         try:
-            import twint
+            import twint  # noqa: F401
         except ImportError:
             raise DepNotInstalledError(
                 "Twitter dependencies are not installed, "

--- a/github_poster/loader/weread_loader.py
+++ b/github_poster/loader/weread_loader.py
@@ -1,7 +1,7 @@
 import pendulum
 import requests
 
-from github_poster.loader.base_loader import BaseLoader, LoadError
+from github_poster.loader.base_loader import BaseLoader
 from github_poster.loader.config import WEREAD_BASE_URL, WEREAD_HISTORY_URL
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,1 @@
-PyGithub
-gpxpy
-stravalib
-svgwrite
-pendulum
-requests
-colour
-# my fork from sdf
-sdf_fork
-# my fork twint for twitter loader
-twint_fork
-# for garmin connect
-garminconnect
+-e .[all]

--- a/setup.py
+++ b/setup.py
@@ -1,35 +1,4 @@
-from os import path
-
 from setuptools import find_packages, setup
-
-loc = path.abspath(path.dirname(__file__))
-
-with open(loc + "/requirements.txt") as f:
-    requirements = f.read().splitlines()
-
-required = []
-dependency_links = []
-
-# Do not add to required lines pointing to Git repositories
-EGG_MARK = "#egg="
-for line in requirements:
-    if (
-        line.startswith("-e git:")
-        or line.startswith("-e git+")
-        or line.startswith("git:")
-        or line.startswith("git+")
-    ):
-        line = line.lstrip("-e ")  # in case that is using "-e"
-        if EGG_MARK in line:
-            package_name = line[line.find(EGG_MARK) + len(EGG_MARK) :]
-            repository = line[: line.find(EGG_MARK)]
-            required.append("%s @ %s" % (package_name, repository))
-            dependency_links.append(line)
-        else:
-            print("Dependency to a git repository should have the format:")
-            print("git+ssh://git@github.com/xxxxx/xxxxxx#egg=package_name")
-    else:
-        required.append(line)
 
 setup(
     name="github_poster",
@@ -41,8 +10,28 @@ setup(
     description="Make everything a GitHub svg poster and Skyline!",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=required,
-    dependency_links=dependency_links,
+    install_requires=[
+        "requests",
+        "svgwrite",
+        "pendulum",
+        "colour",
+    ],
+    extras_require={
+        "twitter": ["twint_fork"],
+        "garmin": ["garminconnect"],
+        "gpx": ["gpxpy"],
+        "strava": ["stravalib"],
+        "github": ["PyGithub"],
+        "skyline": ["sdf_fork"],
+        "all": [
+            "twint_fork",
+            "garminconnect",
+            "gpxpy",
+            "stravalib",
+            "PyGithub",
+            "sdf_fork",
+        ],
+    },
     entry_points={
         "console_scripts": ["github_poster = github_poster.cli:main"],
     },


### PR DESCRIPTION
随着支持的 loader 越来越多，每个 loader 可能会有自己的依赖，导致整个项目的依赖越来越多，但是很多用户实际上并不会用到所有的 loader，导致了一些不必要的依赖安装。

这个 PR 在不做大的重构的条件下，
1. 将各个 loader 的依赖放到了独立的 `extras_require` 中，比如想使用 twitter loader，就需要 `pip install github_poster[twitter]`。默认情况下也提供了 `github_poster[all]` 来简化一些小白用户的使用。
2. 将 loader 的依赖 import 延迟到了真正要使用的时候。为需要额外加载依赖的 loader 提供了 `try_import_deps` 方法，在使用真正的功能前尝试加载它的依赖，如果 import 失败，抛出异常，提示用户需要安装额外的依赖。
