### PR TITLE
Add script to convert Twitter Archive to JSON data source

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -219,6 +219,15 @@ python3 -m github_poster twitter --twitter_user_name ${user_name} --year 2018-20
 or
 github_poster twitter --twitter_user_name ${twitter_user_name} --year 2018-2021 --track-color '#1C9CEA'
 ```
+
+The method above uses [twint](https://github.com/twintproject/twint) to scrape tweets directly from Twitter.
+
+Alternatively, [download your Twitter Archive](https://help.twitter.com/en/managing-your-account/how-to-download-your-twitter-archive) and use `contrib/convert_twitter_archive_to_json_data_source.py` to convert it to JSON data source and feed it to [Json](#Json) loader. This method is useful if one or more of the following applies to you:
+
+- You have lots of tweets.
+- You have been using Twitter for many years.
+- Your connection to Twitter is not reliable enough.
+- You have a protected Twitter account.
 </details>
 
 ### Youtube

--- a/README.md
+++ b/README.md
@@ -275,6 +275,16 @@ python3 -m github_poster twitter --twitter_user_name ${user_name} --year 2018-20
 or
 github_poster twitter --user_name ${twitter_user_name} --year 2018-2021 --track-color '#1C9CEA'
 ```
+
+以上方法使用 [twint](https://github.com/twintproject/twint) 直接从 Twitter 抓取你的推文数据。
+
+你也可以选择[下载 Twitter 存档](https://help.twitter.com/en/managing-your-account/how-to-download-your-twitter-archive)，并使用 `contrib/convert_twitter_archive_to_json_data_source.py` 将其转换为 [Json](#Json) 数据源。这一方法尤其适用于以下情况中的一种或多种：
+
+- 你发过很多推
+- 你使用 Twitter 很多年了
+- 你的网络环境不佳
+- 你是锁推用户
+
 </details>
 
 ### Youtube

--- a/contrib/convert_twitter_archive_to_json_data_source.py
+++ b/contrib/convert_twitter_archive_to_json_data_source.py
@@ -12,7 +12,7 @@ The resulting file serves as an input file to the GitHubPoster JSON data source.
 
 More on your Twitter Archive: https://help.twitter.com/en/managing-your-account/how-to-download-your-twitter-archive
 
-More on GitHubPoster project: https://github.com/wzyboy/GitHubPoster
+More on GitHubPoster project: https://github.com/yihong0618/GitHubPoster
 """
 
 import json

--- a/contrib/convert_twitter_archive_to_json_data_source.py
+++ b/contrib/convert_twitter_archive_to_json_data_source.py
@@ -15,43 +15,49 @@ More on your Twitter Archive: https://help.twitter.com/en/managing-your-account/
 More on GitHubPoster project: https://github.com/yihong0618/GitHubPoster
 """
 
-import json
 import argparse
-from datetime import datetime
+import json
 from collections import Counter
-
+from datetime import datetime
 
 # Wed Jul 08 15:04:01 +0000 2009
-TIMESTAMP_FMT = '%a %b %d %H:%M:%S %z %Y'
+TIMESTAMP_FMT = "%a %b %d %H:%M:%S %z %Y"
 
 
 def convert(input_file, output_file):
 
-    with open(input_file, 'r') as f:
+    with open(input_file, "r") as f:
         content = f.read()
 
     # Read JSON payload from the JavaScript file
-    preamble = 'window.YTD.tweet.part0 = '
-    content = content[len(preamble):]
+    preamble = "window.YTD.tweet.part0 = "
+    content = content[len(preamble) :]
 
     counter = Counter()
     tweets = json.loads(content)
     for tweet in tweets:
-        date = str(datetime.strptime(tweet['tweet']['created_at'], TIMESTAMP_FMT).date())
+        date = str(
+            datetime.strptime(tweet["tweet"]["created_at"], TIMESTAMP_FMT).date()
+        )
         counter[date] += 1
 
-    with open(output_file, 'w') as f:
+    with open(output_file, "w") as f:
         json.dump(counter, f, sort_keys=True, indent=2)
 
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument('input_file', help='tweet.js file extracted from YourTwitterArchive.zip/data')
-    ap.add_argument('output_file', help='path to output file, which can be fed to GitHubPoster JSON loader')
+    ap.add_argument(
+        "input_file", help="tweet.js file extracted from YourTwitterArchive.zip/data"
+    )
+    ap.add_argument(
+        "output_file",
+        help="path to output file, which can be fed to GitHubPoster JSON loader",
+    )
 
     args = ap.parse_args()
     convert(args.input_file, args.output_file)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/contrib/convert_twitter_archive_to_json_data_source.py
+++ b/contrib/convert_twitter_archive_to_json_data_source.py
@@ -10,7 +10,8 @@
 
 The resulting file serves as an input file to the GitHubPoster JSON data source.
 
-More on your Twitter Archive: https://help.twitter.com/en/managing-your-account/how-to-download-your-twitter-archive
+More on your Twitter Archive:
+https://help.twitter.com/en/managing-your-account/how-to-download-your-twitter-archive
 
 More on GitHubPoster project: https://github.com/yihong0618/GitHubPoster
 """

--- a/contrib/convert_twitter_archive_to_json_data_source.py
+++ b/contrib/convert_twitter_archive_to_json_data_source.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+"""This file converts your Twitter Archive data file into a simple JSON file like this:
+
+{
+    "2019-01-01": 123,
+    "2019-01-02": 456,
+    ...
+}
+
+The resulting file serves as an input file to the GitHubPoster JSON data source.
+
+More on your Twitter Archive: https://help.twitter.com/en/managing-your-account/how-to-download-your-twitter-archive
+
+More on GitHubPoster project: https://github.com/wzyboy/GitHubPoster
+"""
+
+import json
+import argparse
+from datetime import datetime
+from collections import Counter
+
+
+# Wed Jul 08 15:04:01 +0000 2009
+TIMESTAMP_FMT = '%a %b %d %H:%M:%S %z %Y'
+
+
+def convert(input_file, output_file):
+
+    with open(input_file, 'r') as f:
+        content = f.read()
+
+    # Read JSON payload from the JavaScript file
+    preamble = 'window.YTD.tweet.part0 = '
+    content = content[len(preamble):]
+
+    counter = Counter()
+    tweets = json.loads(content)
+    for tweet in tweets:
+        date = str(datetime.strptime(tweet['tweet']['created_at'], TIMESTAMP_FMT).date())
+        counter[date] += 1
+
+    with open(output_file, 'w') as f:
+        json.dump(counter, f, sort_keys=True, indent=2)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('input_file', help='tweet.js file extracted from YourTwitterArchive.zip/data')
+    ap.add_argument('output_file', help='path to output file, which can be fed to GitHubPoster JSON loader')
+
+    args = ap.parse_args()
+    convert(args.input_file, args.output_file)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Currently GitHubPoster only supports scraping Twitter data directly from Twitter.com. This process is time-consuming and error-prone due to, for instance, network limits.

If one has a lot of tweets that span a long range of time, it makes more sense to [download a Twitter Archive](https://help.twitter.com/en/managing-your-account/how-to-download-your-twitter-archive) and use that as the data source.

This PR adds a simple script that converts the Twitter Archive into a simple JSON file that can be fed into GitHubPoster's JSON loader.
