### PR TITLE
add loader for apple health data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Mac OS folder attribution file
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README-EN.md
+++ b/README-EN.md
@@ -39,6 +39,7 @@ Make everything a GitHub svg poster and [skyline](https://skyline.github.com/)!
 - **[Summary](#Summary)**
 - **[Todoist](#Todoist)**
 - **[OpenLanguage](#OpenLanguage)**
+- **[Apple Health](#AppleHealth)**
 
 ## Download
 ```
@@ -543,6 +544,33 @@ or
 github_poster openlanguage --year 2021-2022 --openlanguage_user_name "you account" --openlanguage_password "you password" --me "your name"
 ```
 </details>
+
+### AppleHealth
+<details>
+<summary>Make <code> Apple Health </code> GitHub poster</summary>
+
+Apple Health has plenty of data that can be visualized. 
+At this moment this loader only supports Move, Exercise, and Stand data from Apple Watch Activity but any record Apple Health has can be supported in the same way.
+
+Loader has two modes: 
+
+increment mode (default）is good for daily update. iOS Shortcut can be used to trigger a workflow running loader on this mode.
+Read [this repo](https://github.com/yihong0618/iBeats) for more details.
+<br>
+```
+python3 -m github_poster apple_health --date <date-str> --value <value> --apple_health_record_type <move, exercise, stand> --me "your name"
+or
+github_poster apple_health --appple_health_date <date-str> --apple_health_value <value> --apple_health_record_type <move, exercise, stand> --me "your name"
+```
+
+backfill mode is good for dumping all data at once.
+Open the Health App, click on the avatar on the top right corner, select "Export All Health Data" on the bottom, copy the zip file to `IN-FOLDER` and unzip. You will get a `apple_health_export` folder. Then run:
+<br>
+```
+python3 -m github_poster apple_health --apple_health_mode backfill --year 2015-2021 --apple_health_record_type <move, exercise, stand> --me "your name"
+or
+github_poster apple_health --apple_health_mode backfill --year 2015-2021 --apple_health_record_type <move, exercise, stand> --me "your name"
+```
 
 # Contribution
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Make everything a GitHub svg poster and [skyline](https://skyline.github.com/)!
 - **[Covid](#Covid)**
 - **[Todoist](#Todoist)**
 - **[开言英语](#开言英语)**
+- **[Apple Health](#AppleHealth)**
 
 ## 下载
 
@@ -631,6 +632,21 @@ github_poster todoist --year 2021-2022 --todoist_token "your todoist dev token" 
 python3 -m github_poster openlanguage --year 2021-2022 --openlanguage_user_name "you account" --openlanguage_password "you password" --me "your name"
 or
 github_poster openlanguage --year 2021-2022 --openlanguage_user_name "you account" --openlanguage_password "you password" --me "your name"
+```
+</details>
+
+### AppleHealth
+<details>
+<summary>Make <code> Apple Health </code> GitHub poster</summary>
+
+Apple Health 里有丰富的数据，此 loader 暂时只支持 Apple Watch Activity 里的三大项，即 Move，Exercise，Stand。但理论上任何 Apple Health 里的数据都能支持。
+打开 Health App, 点击右上方头像，选择 Export All Health Data, 将所得压缩包拷贝到 `IN-FOLDER` 后解压，会得到一个 `apple_health_export` 文件夹。之后运行:
+<br>
+
+```
+python3 -m github_poster apple_health --year 2015-2021 --apple_health_record_type <move, exercise, stand> --me "your name"
+or
+github_poster apple_health --year 2015-2021 --apple_health_record_type <move, exercise, stand> --me "your name"
 ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -640,14 +640,26 @@ github_poster openlanguage --year 2021-2022 --openlanguage_user_name "you accoun
 <summary>Make <code> Apple Health </code> GitHub poster</summary>
 
 Apple Health 里有丰富的数据，此 loader 暂时只支持 Apple Watch Activity 里的三大项，即 Move，Exercise，Stand。但理论上任何 Apple Health 里的数据都能支持。
+
+Loader 支持两种模式: 
+
+increment 模式（默认）适用于每日更新，可利用 Shortcut 每日自动触发，参考 https://github.com/yihong0618/iBeats
+<br>
+```
+python3 -m github_poster apple_health --date <date-str> --value <value> --apple_health_record_type <move, exercise, stand> --me "your name"
+or
+github_poster apple_health --appple_health_date <date-str> --apple_health_value <value> --apple_health_record_type <move, exercise, stand> --me "your name"
+```
+
+backfill 模式适用于一次性导入所有数据。
 打开 Health App, 点击右上方头像，选择 Export All Health Data, 将所得压缩包拷贝到 `IN-FOLDER` 后解压，会得到一个 `apple_health_export` 文件夹。之后运行:
 <br>
-
 ```
-python3 -m github_poster apple_health --year 2015-2021 --apple_health_record_type <move, exercise, stand> --me "your name"
+python3 -m github_poster apple_health --apple_health_mode backfill --year 2015-2021 --apple_health_record_type <move, exercise, stand> --me "your name"
 or
-github_poster apple_health --year 2015-2021 --apple_health_record_type <move, exercise, stand> --me "your name"
+github_poster apple_health --apple_health_mode backfill --year 2015-2021 --apple_health_record_type <move, exercise, stand> --me "your name"
 ```
+
 </details>
 
 # 参与项目

--- a/github_poster/config.py
+++ b/github_poster/config.py
@@ -47,4 +47,5 @@ TYPE_INFO_DICT = {
     "weread": "WeRead",
     "covid": "COVID-19",
     "todoist": "Todoist",
+    "apple": "AppleHealth",
 }

--- a/github_poster/loader/__init__.py
+++ b/github_poster/loader/__init__.py
@@ -1,3 +1,4 @@
+from github_poster.loader.apple_health_loader import AppleHealthLoader
 from github_poster.loader.bbdc_loader import BBDCLoader
 from github_poster.loader.bilibili_loader import BilibiliLoader
 from github_poster.loader.cichang_loader import CiChangLoader
@@ -29,6 +30,7 @@ from github_poster.loader.weread_loader import WereadLoader
 from github_poster.loader.youtube_loader import YouTubeLoader
 
 LOADER_DICT = {
+    "apple_health": AppleHealthLoader,
     "bbdc": BBDCLoader,
     "duolingo": DuolingoLoader,
     "shanbay": ShanBayLoader,
@@ -61,6 +63,7 @@ LOADER_DICT = {
 }
 
 __all__ = (
+    "AppleHealthLoader",
     "BilibiliLoader",
     "CiChangLoader",
     "Dota2Loader",

--- a/github_poster/loader/apple_health_loader.py
+++ b/github_poster/loader/apple_health_loader.py
@@ -1,0 +1,91 @@
+import os
+import xml.etree.ElementTree as ET
+from collections import defaultdict, namedtuple
+
+import pendulum
+
+from github_poster.loader.base_loader import BaseLoader
+
+# func is a lambda that converts the "value" attribute of the record to a numeric value.
+RecordMetadata = namedtuple("RecordMetadata", ["type", "unit", "track_color", "func"])
+
+
+SUPPORTED_HEALTH_RECORD_TYPES = {
+    "move": RecordMetadata(
+        "HKQuantityTypeIdentifierActiveEnergyBurned",
+        "kCal",
+        "#ED619C",
+        lambda x: float(x),
+    ),
+    "exercise": RecordMetadata(
+        "HKQuantityTypeIdentifierAppleExerciseTime", "mins", "#D7FD37", lambda x: int(x)
+    ),
+    "stand": RecordMetadata(
+        "HKCategoryTypeIdentifierAppleStandHour",
+        "hours",
+        "#62F90B",
+        lambda x: 1 if "HKCategoryValueAppleStandHourStood" else 0,
+    ),
+}
+
+
+class AppleHealthLoader(BaseLoader):
+    def __init__(self, from_year, to_year, _type, **kwargs):
+        super().__init__(from_year, to_year, _type)
+        self.number_by_date_dict = defaultdict(int)
+        self.apple_health_export_file = kwargs.get("apple_health_export_file")
+        self.apple_health_record_type = kwargs.get("apple_health_record_type")
+
+    @classmethod
+    def add_loader_arguments(cls, parser, optional):
+        parser.add_argument(
+            "--apple_health_export_file",
+            dest="apple_health_export_file",
+            type=str,
+            default=os.path.join("IN_FOLDER", "apple_health_export", "export.xml"),
+            help="Apple Health export file path",
+        )
+        parser.add_argument(
+            "--apple_health_record_type",
+            dest="apple_health_record_type",
+            choices=SUPPORTED_HEALTH_RECORD_TYPES.keys(),
+            default="move",
+            help="Apple Health Record Type",
+        )
+
+    def make_track_dict(self):
+        record_metadata = SUPPORTED_HEALTH_RECORD_TYPES[self.apple_health_record_type]
+        self.__class__.unit = record_metadata.unit
+        self.__class__.track_color = record_metadata.track_color
+
+        in_target_section = False
+        for _, elem in ET.iterparse(self.apple_health_export_file, events=["end"]):
+            if elem.tag != "Record":
+                continue
+
+            if elem.attrib["type"] == record_metadata.type:
+                in_target_section = True
+                create_date = pendulum.from_format(
+                    elem.attrib["creationDate"], "YYYY-MM-DD HH:mm:ss ZZ"
+                )
+                if (
+                    create_date.year >= self.from_year
+                    and create_date.year <= self.to_year
+                ):
+                    self.number_by_date_dict[
+                        create_date.to_date_string()
+                    ] += record_metadata.func(elem.attrib["value"])
+            elif in_target_section:
+                break
+
+            elem.clear()
+
+        self.number_by_date_dict = {
+            k: int(v) for k, v in self.number_by_date_dict.items()
+        }
+        self.number_list = list(self.number_by_date_dict.values())
+
+    def get_all_track_data(self):
+        self.make_track_dict()
+        self.make_special_number()
+        return self.number_by_date_dict, self.year_list

--- a/github_poster/loader/apple_health_loader.py
+++ b/github_poster/loader/apple_health_loader.py
@@ -1,6 +1,9 @@
+import json
 import os
 import xml.etree.ElementTree as ET
 from collections import defaultdict, namedtuple
+from numbers import Number
+from typing import Dict
 
 import pendulum
 
@@ -10,7 +13,7 @@ from github_poster.loader.base_loader import BaseLoader
 RecordMetadata = namedtuple("RecordMetadata", ["type", "unit", "track_color", "func"])
 
 
-SUPPORTED_HEALTH_RECORD_TYPES = {
+HEALTH_RECORD_TYPES = {
     "move": RecordMetadata(
         "HKQuantityTypeIdentifierActiveEnergyBurned",
         "kCal",
@@ -30,14 +33,40 @@ SUPPORTED_HEALTH_RECORD_TYPES = {
 
 
 class AppleHealthLoader(BaseLoader):
+    HISTORY_FILE = os.path.join("IN_FOLDER", "apple_history.json")
+
     def __init__(self, from_year, to_year, _type, **kwargs):
         super().__init__(from_year, to_year, _type)
-        self.number_by_date_dict = defaultdict(int)
+        self.archive: Dict[str, Dict[str, Number]] = {}
+        self.number_by_date_dict: Dict[str, Number] = {}
         self.apple_health_export_file = kwargs.get("apple_health_export_file")
         self.apple_health_record_type = kwargs.get("apple_health_record_type")
+        self.apple_health_date = kwargs.get("apple_health_date")
+        self.apple_health_value = kwargs.get("apple_health_value")
+        self.apple_health_mode = kwargs.get("apple_health_mode")
+        self.record_metadata = HEALTH_RECORD_TYPES[self.apple_health_record_type]
 
     @classmethod
     def add_loader_arguments(cls, parser, optional):
+        parser.add_argument(
+            "--apple_health_date",
+            dest="apple_health_date",
+            type=str,
+            help="Apple Health record date",
+        )
+        parser.add_argument(
+            "--apple_health_value",
+            dest="apple_health_value",
+            type=str,
+            help="Apple Health record value",
+        )
+        parser.add_argument(
+            "--apple_health_mode",
+            dest="apple_health_mode",
+            choices=["backfill", "incremental"],
+            default="incremental",
+            help="Apple Health loader mode, backfill will read from export records, incremental will read from input",
+        )
         parser.add_argument(
             "--apple_health_export_file",
             dest="apple_health_export_file",
@@ -48,42 +77,63 @@ class AppleHealthLoader(BaseLoader):
         parser.add_argument(
             "--apple_health_record_type",
             dest="apple_health_record_type",
-            choices=SUPPORTED_HEALTH_RECORD_TYPES.keys(),
+            choices=HEALTH_RECORD_TYPES.keys(),
             default="move",
             help="Apple Health Record Type",
         )
 
+    def _load_apple_health_history(self):
+        if os.path.exists(self.HISTORY_FILE):
+            with open(self.HISTORY_FILE, "r") as f:
+                self.archive = json.load(f)
+                self.number_by_date_dict = self.archive.get(
+                    self.apple_health_record_type, {}
+                )
+
+    def _write_apple_health_history(self):
+        self.archive[self.apple_health_record_type] = self.number_by_date_dict
+        with open(self.HISTORY_FILE, "w") as f:
+            json.dump(self.archive, f, sort_keys=True)
+
     def make_track_dict(self):
-        record_metadata = SUPPORTED_HEALTH_RECORD_TYPES[self.apple_health_record_type]
-        self.__class__.unit = record_metadata.unit
-        self.__class__.track_color = record_metadata.track_color
+        self.__class__.unit = self.record_metadata.unit
+        self.__class__.track_color = self.record_metadata.track_color
+
+        self._load_apple_health_history()
+        getattr(self, self.apple_health_mode)()
+        self._write_apple_health_history()
+        self.number_list = list(self.number_by_date_dict.values())
+
+    def incremental(self):
+        date_str = pendulum.parse(self.apple_health_date).to_date_string()
+        value = self.record_metadata.func(self.apple_health_value)
+        self.number_by_date_dict[date_str] = value
+
+    def backfill(self):
+        from_export = defaultdict(int)
 
         in_target_section = False
         for _, elem in ET.iterparse(self.apple_health_export_file, events=["end"]):
             if elem.tag != "Record":
                 continue
 
-            if elem.attrib["type"] == record_metadata.type:
+            if elem.attrib["type"] == self.record_metadata.type:
                 in_target_section = True
-                create_date = pendulum.from_format(
+                created = pendulum.from_format(
                     elem.attrib["creationDate"], "YYYY-MM-DD HH:mm:ss ZZ"
                 )
-                if (
-                    create_date.year >= self.from_year
-                    and create_date.year <= self.to_year
-                ):
-                    self.number_by_date_dict[
-                        create_date.to_date_string()
-                    ] += record_metadata.func(elem.attrib["value"])
+                if created.year >= self.from_year and created.year <= self.to_year:
+                    from_export[created.to_date_string()] += self.record_metadata.func(
+                        elem.attrib["value"]
+                    )
             elif in_target_section:
                 break
 
             elem.clear()
 
-        self.number_by_date_dict = {
-            k: int(v) for k, v in self.number_by_date_dict.items()
-        }
-        self.number_list = list(self.number_by_date_dict.values())
+        for k, v in from_export.items():
+            if k not in self.number_by_date_dict:
+                self.number_by_date_dict[k] = v
 
     def get_all_track_data(self):
         self.make_track_dict()


### PR DESCRIPTION
用类似Youtube loader的思路实现Apple Health Data Loader。

Apple Health 提供丰富的数据，支持一键导出XML，目前暂时支持 Apple Watch 收集的三大数据，Move，Exercise，Stand，但理论上所有XML里有的数据都可以支持，只需要拓展 `SUPPORTED_HEALTH_RECORD_TYPES`。